### PR TITLE
Messageモデル単体テストコード修正

### DIFF
--- a/spec/factories/contents.rb
+++ b/spec/factories/contents.rb
@@ -4,5 +4,6 @@ FactoryBot.define do
     media_id                 {"2"}
     genre_id              {"2"}
     introduction        {"11111111111111122222222222222222223333333333333333344444444444444444444"}
+    association :user
   end
 end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -5,5 +5,4 @@ FactoryBot.define do
     user_id              {"2"}
     content_id           {"2"}
   end
-
 end

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :message do
     point              {"2"}
     text                {"1111112222233333"}
-    user_id              {"2"}
-    content_id           {"2"}
+    association :user
+    association :content
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    name              {"yamada"}
+    email                {"nanashi@gmail.com"}
+    password              {"yamada123"}
+    password_confirmation {password}
+  end
+end

--- a/spec/models/content_spec.rb
+++ b/spec/models/content_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Content do
+RSpec.describe Content, type: :model do
   before do
     @content = FactoryBot.build(:content)
   end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-describe Message do
+RSpec.describe Message, type: :model do
   before do
     @message = FactoryBot.build(:message)
   end

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -11,15 +11,15 @@ RSpec.describe Message, type: :model do
       end
     end
     context 'コンテンツ投稿がうまくいかない時' do
-      it "pointが洗濯してください以外の時" do
+      it "pointが選択してください以外の時" do
         @message.point = "1"
-        @content.valid?
+        @message.valid?
         expect(@message.errors.full_messages).to include("Point must be other than 1")
       end
-      it "introductionが空の時" do
-        @content.text = nil
-        @content.valid?
-        expect(@content.errors.full_messages).to include("Text can't be blank")
+      it "textが空の時" do
+        @message.text = nil
+        @message.valid?
+        expect(@message.errors.full_messages).to include("Text can't be blank")
       end
     end
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
# What
Messageモデルの単体テストコード不具合を修正した。

# Why
不具合により実行できなかったため。

# 原因
開発者の認識不足により、アソシエーションによってuserのインスタンスが必須だったところを、その生成用のファイルを作成していなかったためテストが実行できなかった。
その点を解消する実装を行った。